### PR TITLE
fix: update AdminConsole to load journals conditionally based on auth…

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -105,9 +105,17 @@ const AdminConsole: React.FC = () => {
   };
 
   useEffect(() => {
-    loadJournals();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (status === 'authenticated' && isAdmin) {
+      loadJournals({ showLoading: true });
+      return;
+    }
+
+    // Ensure login/non-admin views do not surface stale journal loading errors.
+    setMessage(null);
+    setJournals([]);
+    setLoading(false);
+    setRefreshing(false);
+  }, [status, isAdmin]);
 
   const setJournalOrder = async (journal: Journal, order: number) => {
     // send full journal payload (PUT requires journalName and url)


### PR DESCRIPTION
This pull request updates the `AdminConsole` component to improve how journal data is loaded and how state is managed when authentication or admin status changes. The main change is that journals are now only loaded when the user is authenticated and has admin privileges, and the state is reset appropriately otherwise.

**Authentication and Journal Loading Logic:**

* Updated the `useEffect` dependency list to include `status` and `isAdmin`, ensuring that journals are only loaded when the user is authenticated and is an admin. If not, journal-related state and messages are reset to prevent stale data or errors from being shown.…entication and admin status